### PR TITLE
Remove example feats, get examples building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ embedded-io-async = { version = "0.6.1" }
 nb = "1.1.0"
 
 [dev-dependencies]
+defmt = "1.0"
 defmt-rtt = "1.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 
@@ -52,51 +53,39 @@ unstable-pac = []
 
 [[example]]
 name = "hello"
-required-features = ["lpuart2"]
 
 [[example]]
 name = "blink"
-required-features = ["gpio", "ostimer0"]
 
 [[example]]
 name = "uart_interrupt"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "ostimer_alarm"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "ostimer_async"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "ostimer_counter"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "ostimer_race_test"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "lpuart_polling"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "lpuart_buffered"
-required-features = ["lpuart2", "ostimer0"]
 
 [[example]]
 name = "rtc_alarm"
-required-features = ["lpuart2", "rtc0"]
 
 [[example]]
 name = "adc_polling"
-required-features = ["adc1", "lpuart2"]
 
 [[example]]
 name = "adc_interrupt"
-required-features = ["adc1", "lpuart2"]
 
 [profile.release]
 debug = 2

--- a/examples/adc_interrupt.rs
+++ b/examples/adc_interrupt.rs
@@ -3,11 +3,11 @@
 
 use embassy_executor::Spawner;
 use hal::adc::{LpadcConfig, TriggerPriorityPolicy};
-use hal::pac::adc1::cfg::{Pwrsel, Refsel};
-use hal::pac::adc1::cmdl1::{Adch, Mode};
-use hal::pac::adc1::ctrl::CalAvgs;
-use hal::pac::adc1::tctrl::Tcmd;
 use hal::uart;
+use mcxa_pac::adc1::cfg::{Pwrsel, Refsel};
+use mcxa_pac::adc1::cmdl1::{Adch, Mode};
+use mcxa_pac::adc1::ctrl::CalAvgs;
+use mcxa_pac::adc1::tctrl::Tcmd;
 use {cortex_m, embassy_mcxa276 as hal};
 mod common;
 

--- a/examples/adc_polling.rs
+++ b/examples/adc_polling.rs
@@ -4,11 +4,11 @@
 use embassy_executor::Spawner;
 use embassy_mcxa276 as hal;
 use hal::adc::{ConvResult, LpadcConfig, TriggerPriorityPolicy};
-use hal::pac::adc1::cfg::{Pwrsel, Refsel};
-use hal::pac::adc1::cmdl1::{Adch, Mode};
-use hal::pac::adc1::ctrl::CalAvgs;
-use hal::pac::adc1::tctrl::Tcmd;
 use hal::uart;
+use mcxa_pac::adc1::cfg::{Pwrsel, Refsel};
+use mcxa_pac::adc1::cmdl1::{Adch, Mode};
+use mcxa_pac::adc1::ctrl::CalAvgs;
+use mcxa_pac::adc1::tctrl::Tcmd;
 
 mod common;
 

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,13 +1,13 @@
 //! Shared board-specific helpers for the FRDM-MCXA276 examples.
 //! These live with the examples so the HAL stays generic.
 
-use embassy_mcxa276 as hal;
 use hal::{clocks, pins, reset};
+use {embassy_mcxa276 as hal, panic_probe as _};
 
 /// Initialize clocks and pin muxing for UART2 debug console.
 /// Safe to call multiple times; writes are idempotent for our use.
 #[allow(dead_code)]
-pub unsafe fn init_uart2(p: &hal::pac::Peripherals) {
+pub unsafe fn init_uart2(p: &mcxa_pac::Peripherals) {
     clocks::ensure_frolf_running(p);
     clocks::enable_uart2_port2(p);
     reset::release_reset_port2(p);
@@ -18,7 +18,7 @@ pub unsafe fn init_uart2(p: &hal::pac::Peripherals) {
 
 /// Initialize clocks for the LED GPIO/PORT used by the blink example.
 #[allow(dead_code)]
-pub unsafe fn init_led(p: &hal::pac::Peripherals) {
+pub unsafe fn init_led(p: &mcxa_pac::Peripherals) {
     clocks::enable_led_port(p);
     reset::release_reset_gpio3(p);
     reset::release_reset_port3(p);
@@ -26,7 +26,7 @@ pub unsafe fn init_led(p: &hal::pac::Peripherals) {
 
 /// Initialize clocks for OSTIMER0 (1 MHz source).
 #[allow(dead_code)]
-pub unsafe fn init_ostimer0(p: &hal::pac::Peripherals) {
+pub unsafe fn init_ostimer0(p: &mcxa_pac::Peripherals) {
     clocks::ensure_frolf_running(p);
     clocks::enable_ostimer0(p);
     reset::release_reset_ostimer0(p);
@@ -35,7 +35,7 @@ pub unsafe fn init_ostimer0(p: &hal::pac::Peripherals) {
 
 /// Initialize clocks and pin muxing for ADC.
 #[allow(dead_code)]
-pub unsafe fn init_adc(p: &hal::pac::Peripherals) {
+pub unsafe fn init_adc(p: &mcxa_pac::Peripherals) {
     clocks::ensure_frolf_running(p);
     clocks::enable_adc(p);
     reset::release_reset_port1(p);

--- a/examples/lpuart_buffered.rs
+++ b/examples/lpuart_buffered.rs
@@ -26,7 +26,7 @@ async fn main(_spawner: Spawner) {
     let p2 = lpuart::lib::init();
 
     unsafe {
-        hal::interrupt::install_irq_handler(mcxa276_pac::Interrupt::LPUART2, lpuart2_handler);
+        hal::interrupt::install_irq_handler(mcxa_pac::Interrupt::LPUART2, lpuart2_handler);
     }
 
     // Configure NVIC for LPUART2

--- a/examples/ostimer_race_test.rs
+++ b/examples/ostimer_race_test.rs
@@ -267,7 +267,7 @@ async fn test_concurrent_operations(
 async fn test_reset_during_operation(
     ostimer: &hal::ostimer::Ostimer<'_, hal::ostimer::Ostimer0>,
     uart: &mut hal::uart::Uart<hal::uart::Lpuart2>,
-    peripherals: &hal::pac::Peripherals,
+    peripherals: &mcxa_pac::Peripherals,
 ) {
     let initial_counter = ostimer.now();
 


### PR DESCRIPTION
No CI, but this can be checked with `cargo check --all --examples`, which now succeeds.